### PR TITLE
feat(ANDPERF-10): add metric capability model foundation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ benchmark = "1.4.1"
 runner = "1.7.0"
 uiautomator = "2.3.0"
 profileinstaller = "1.4.1"
+kotlinxSerialization = "1.7.3"
 
 [libraries]
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
@@ -30,9 +31,11 @@ benchmark-macro = { module = "androidx.benchmark:benchmark-macro-junit4", versio
 benchmark-junit4 = { module = "androidx.benchmark:benchmark-junit4", version.ref = "benchmark" }
 uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "uiautomator" }
 profileinstaller = { module = "androidx.profileinstaller:profileinstaller", version.ref = "profileinstaller" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -19,4 +20,9 @@ android {
 
 kotlin {
     jvmToolchain(17)
+}
+
+dependencies {
+    implementation(libs.kotlinx.serialization.json)
+    testImplementation(kotlin("test"))
 }

--- a/shared/src/main/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModels.kt
+++ b/shared/src/main/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModels.kt
@@ -75,7 +75,7 @@ enum class AvailabilityReason(val friendlyMessage: String) {
 data class MetricCapability(
     val metric: MetricType,
     val supported: Boolean,
-    val reason: AvailabilityReason = AvailabilityReason.SUPPORTED,
+    val reason: AvailabilityReason,
     val details: String? = null
 ) {
     val message: String

--- a/shared/src/main/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModels.kt
+++ b/shared/src/main/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModels.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 Compose-vs-Android-View-System-Performance
+ *
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+package dev.egarcia.andperf.shared.capability
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Canonical metric families understood by the benchmark suite.
+ */
+@Serializable
+enum class MetricType {
+    @SerialName("startup")
+    STARTUP,
+
+    @SerialName("frame_timing")
+    FRAME_TIMING,
+
+    @SerialName("power")
+    POWER,
+
+    @SerialName("memory")
+    MEMORY,
+
+    @SerialName("thermal")
+    THERMAL,
+
+    @SerialName("network")
+    NETWORK
+}
+
+/**
+ * Reasons describing why a metric is or is not supported on a given device/OS.
+ */
+@Serializable
+enum class AvailabilityReason(val friendlyMessage: String) {
+    @SerialName("supported")
+    SUPPORTED("Metric can be collected on this configuration."),
+
+    @SerialName("os_too_old")
+    OS_TOO_OLD("Android version below required API level."),
+
+    @SerialName("hw_unsupported")
+    HW_UNSUPPORTED("Device hardware counters are missing."),
+
+    @SerialName("permission_denied")
+    PERMISSION_DENIED("Missing shell or adb permissions for this probe."),
+
+    @SerialName("no_data_collected")
+    NO_DATA_COLLECTED("Benchmark produced no samples for the metric."),
+
+    @SerialName("runtime_error")
+    RUNTIME_ERROR("Unexpected runtime failure while measuring."),
+
+    @SerialName("not_configured")
+    NOT_CONFIGURED("Benchmark task skipped because it was not configured."),
+
+    @SerialName("unknown")
+    UNKNOWN("Metric capability is unknown.");
+
+    /**
+     * Resolve a user-facing message, preferring a caller supplied detail string.
+     */
+    fun resolveMessage(details: String?): String = details?.takeIf { it.isNotBlank() } ?: friendlyMessage
+}
+
+/**
+ * Immutable description of the capability status for a single metric.
+ */
+@Serializable
+data class MetricCapability(
+    val metric: MetricType,
+    val supported: Boolean,
+    val reason: AvailabilityReason = AvailabilityReason.SUPPORTED,
+    val details: String? = null
+) {
+    val message: String
+        get() = reason.resolveMessage(details)
+}
+
+/**
+ * Snapshot of the device/OS data captured when a probe is executed.
+ */
+@Serializable
+data class DeviceInfo(
+    val manufacturer: String,
+    val model: String,
+    val device: String,
+    val sdkInt: Int,
+    val abi: String,
+    val buildId: String,
+    val fingerprint: String
+)

--- a/shared/src/test/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModelsTest.kt
+++ b/shared/src/test/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModelsTest.kt
@@ -1,0 +1,60 @@
+package dev.egarcia.andperf.shared.capability
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MetricCapabilityModelsTest {
+
+    private val json = Json {
+        encodeDefaults = true
+        prettyPrint = false
+    }
+
+    @Test
+    fun `resolveMessage prefers explicit details`() {
+        val capability = MetricCapability(
+            metric = MetricType.STARTUP,
+            supported = false,
+            reason = AvailabilityReason.OS_TOO_OLD,
+            details = "Requires API 29+"
+        )
+
+        assertEquals("Requires API 29+", capability.message)
+    }
+
+    @Test
+    fun `capability serializes with snake_case metric names`() {
+        val capability = MetricCapability(
+            metric = MetricType.FRAME_TIMING,
+            supported = false,
+            reason = AvailabilityReason.NO_DATA_COLLECTED
+        )
+
+        val payload = json.encodeToString(capability)
+        assertTrue(payload.contains("\"metric\":\"frame_timing\""))
+        assertTrue(payload.contains("\"reason\":\"no_data_collected\""))
+
+        val decoded = Json.decodeFromString<MetricCapability>(payload)
+        assertEquals(capability, decoded)
+    }
+
+    @Test
+    fun `device info round trip retains identity`() {
+        val info = DeviceInfo(
+            manufacturer = "Google",
+            model = "Pixel 8",
+            device = "shiba",
+            sdkInt = 34,
+            abi = "arm64-v8a",
+            buildId = "AP4A.250105.001",
+            fingerprint = "google/shiba/shiba:14/AP4A.250105.001/123:user/release-keys"
+        )
+
+        val payload = json.encodeToString(info)
+        val decoded = Json.decodeFromString<DeviceInfo>(payload)
+        assertEquals(info, decoded)
+    }
+}

--- a/shared/src/test/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModelsTest.kt
+++ b/shared/src/test/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModelsTest.kt
@@ -42,6 +42,47 @@ class MetricCapabilityModelsTest {
     }
 
     @Test
+    fun `resolveMessage falls back to friendly message when details missing`() {
+        val capability = MetricCapability(
+            metric = MetricType.FRAME_TIMING,
+            supported = false,
+            reason = AvailabilityReason.NO_DATA_COLLECTED,
+            details = null
+        )
+
+        assertEquals(AvailabilityReason.NO_DATA_COLLECTED.friendlyMessage, capability.message)
+    }
+
+    @Test
+    fun `resolveMessage falls back to friendly message when details blank`() {
+        val capability = MetricCapability(
+            metric = MetricType.STARTUP,
+            supported = false,
+            reason = AvailabilityReason.OS_TOO_OLD,
+            details = "   "
+        )
+
+        assertEquals(AvailabilityReason.OS_TOO_OLD.friendlyMessage, capability.message)
+    }
+
+    @Test
+    fun `supported capability serializes and reports friendly message`() {
+        val capability = MetricCapability(
+            metric = MetricType.POWER,
+            supported = true,
+            reason = AvailabilityReason.SUPPORTED
+        )
+
+        val payload = json.encodeToString(capability)
+        assertTrue(payload.contains("\"metric\":\"power\""))
+        assertTrue(payload.contains("\"reason\":\"supported\""))
+
+        val decoded = Json.decodeFromString<MetricCapability>(payload)
+        assertEquals(capability, decoded)
+        assertEquals(AvailabilityReason.SUPPORTED.friendlyMessage, capability.message)
+    }
+
+    @Test
     fun `device info round trip retains identity`() {
         val info = DeviceInfo(
             manufacturer = "Google",


### PR DESCRIPTION
Add MetricType/AvailabilityReason/MetricCapability/DeviceInfo data models with Kotlinx serialization support in the shared module, wire plugin/dependencies, and cover serialization + messaging behavior with unit tests.

Closes #10