### PR TITLE
test: add benchmark metric selection coverage

### DIFF
--- a/shared/src/main/java/dev/egarcia/andperf/shared/capability/BenchmarkMetricSelection.kt
+++ b/shared/src/main/java/dev/egarcia/andperf/shared/capability/BenchmarkMetricSelection.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Compose-vs-Android-View-System-Performance
+ *
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+package dev.egarcia.andperf.shared.capability
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Pure metric-selection request used before instrumentation-only metric objects
+ * are created.
+ */
+@Serializable
+data class MetricSelectionRequest(
+    val requestedMetrics: List<MetricType>,
+    val requiredMetrics: Set<MetricType> = emptySet()
+) {
+    init {
+        require(requestedMetrics.isNotEmpty()) { "At least one metric must be requested." }
+        require(requiredMetrics.all { it in requestedMetrics }) {
+            "Required metrics must also be present in requestedMetrics."
+        }
+    }
+}
+
+/**
+ * Deterministic result of sanitizing a requested metric set against known
+ * capabilities.
+ */
+@Serializable
+data class MetricSelectionResult(
+    val requestedMetrics: List<MetricType>,
+    val selectedMetrics: List<MetricType>,
+    val skippedMetrics: List<MetricCapability>,
+    val requiredMetricsSatisfied: Boolean
+) {
+    val canRun: Boolean
+        get() = selectedMetrics.isNotEmpty() && requiredMetricsSatisfied
+}
+
+/**
+ * Device-independent metric selection logic. Instrumented code can probe the
+ * device/OS and then pass the resulting [MetricCapability] values here before
+ * building AndroidX Macrobenchmark Metric instances.
+ */
+object BenchmarkMetricSelector {
+
+    fun select(
+        request: MetricSelectionRequest,
+        capabilities: Collection<MetricCapability>
+    ): MetricSelectionResult {
+        val capabilityByMetric = capabilities.associateBy { it.metric }
+        val selected = mutableListOf<MetricType>()
+        val skipped = mutableListOf<MetricCapability>()
+
+        request.requestedMetrics.distinct().forEach { metric ->
+            val capability = capabilityByMetric[metric] ?: MetricCapability(
+                metric = metric,
+                supported = false,
+                reason = AvailabilityReason.UNKNOWN,
+                details = "No capability probe result was provided for $metric."
+            )
+
+            if (capability.supported) {
+                selected += metric
+            } else {
+                skipped += capability
+            }
+        }
+
+        val requiredSatisfied = request.requiredMetrics.all { it in selected }
+        return MetricSelectionResult(
+            requestedMetrics = request.requestedMetrics.distinct(),
+            selectedMetrics = selected,
+            skippedMetrics = skipped,
+            requiredMetricsSatisfied = requiredSatisfied
+        )
+    }
+}

--- a/shared/src/main/java/dev/egarcia/andperf/shared/capability/BenchmarkMetricSelection.kt
+++ b/shared/src/main/java/dev/egarcia/andperf/shared/capability/BenchmarkMetricSelection.kt
@@ -55,7 +55,8 @@ object BenchmarkMetricSelector {
         val selected = mutableListOf<MetricType>()
         val skipped = mutableListOf<MetricCapability>()
 
-        request.requestedMetrics.distinct().forEach { metric ->
+        val uniqueRequested = request.requestedMetrics.distinct()
+        uniqueRequested.forEach { metric ->
             val capability = capabilityByMetric[metric] ?: MetricCapability(
                 metric = metric,
                 supported = false,
@@ -72,7 +73,7 @@ object BenchmarkMetricSelector {
 
         val requiredSatisfied = request.requiredMetrics.all { it in selected }
         return MetricSelectionResult(
-            requestedMetrics = request.requestedMetrics.distinct(),
+            requestedMetrics = uniqueRequested,
             selectedMetrics = selected,
             skippedMetrics = skipped,
             requiredMetricsSatisfied = requiredSatisfied

--- a/shared/src/test/java/dev/egarcia/andperf/shared/capability/BenchmarkMetricSelectionTest.kt
+++ b/shared/src/test/java/dev/egarcia/andperf/shared/capability/BenchmarkMetricSelectionTest.kt
@@ -1,0 +1,167 @@
+package dev.egarcia.andperf.shared.capability
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class BenchmarkMetricSelectionTest {
+
+    private val json = Json {
+        encodeDefaults = true
+        prettyPrint = false
+    }
+
+    @Test
+    fun `select keeps supported metrics in requested order`() {
+        val result = BenchmarkMetricSelector.select(
+            request = MetricSelectionRequest(
+                requestedMetrics = listOf(MetricType.STARTUP, MetricType.FRAME_TIMING)
+            ),
+            capabilities = listOf(
+                MetricCapability(MetricType.FRAME_TIMING, supported = true, reason = AvailabilityReason.SUPPORTED),
+                MetricCapability(MetricType.STARTUP, supported = true, reason = AvailabilityReason.SUPPORTED)
+            )
+        )
+
+        assertEquals(listOf(MetricType.STARTUP, MetricType.FRAME_TIMING), result.selectedMetrics)
+        assertEquals(emptyList(), result.skippedMetrics)
+        assertTrue(result.requiredMetricsSatisfied)
+        assertTrue(result.canRun)
+    }
+
+    @Test
+    fun `select records unsupported metrics with probe reason`() {
+        val result = BenchmarkMetricSelector.select(
+            request = MetricSelectionRequest(
+                requestedMetrics = listOf(MetricType.STARTUP, MetricType.FRAME_TIMING)
+            ),
+            capabilities = listOf(
+                MetricCapability(MetricType.STARTUP, supported = true, reason = AvailabilityReason.SUPPORTED),
+                MetricCapability(
+                    metric = MetricType.FRAME_TIMING,
+                    supported = false,
+                    reason = AvailabilityReason.NO_DATA_COLLECTED,
+                    details = "No frameDurationCpuMs samples were emitted."
+                )
+            )
+        )
+
+        assertEquals(listOf(MetricType.STARTUP), result.selectedMetrics)
+        assertEquals(
+            listOf(
+                MetricCapability(
+                    metric = MetricType.FRAME_TIMING,
+                    supported = false,
+                    reason = AvailabilityReason.NO_DATA_COLLECTED,
+                    details = "No frameDurationCpuMs samples were emitted."
+                )
+            ),
+            result.skippedMetrics
+        )
+        assertTrue(result.canRun)
+    }
+
+    @Test
+    fun `select treats missing capability as unknown skipped metric`() {
+        val result = BenchmarkMetricSelector.select(
+            request = MetricSelectionRequest(
+                requestedMetrics = listOf(MetricType.STARTUP, MetricType.POWER)
+            ),
+            capabilities = listOf(
+                MetricCapability(MetricType.STARTUP, supported = true, reason = AvailabilityReason.SUPPORTED)
+            )
+        )
+
+        assertEquals(listOf(MetricType.STARTUP), result.selectedMetrics)
+        assertEquals(1, result.skippedMetrics.size)
+        assertEquals(MetricType.POWER, result.skippedMetrics.single().metric)
+        assertEquals(AvailabilityReason.UNKNOWN, result.skippedMetrics.single().reason)
+        assertTrue(result.skippedMetrics.single().message.contains("No capability probe result"))
+    }
+
+    @Test
+    fun `required unsupported metric prevents run even when optional metric is selected`() {
+        val result = BenchmarkMetricSelector.select(
+            request = MetricSelectionRequest(
+                requestedMetrics = listOf(MetricType.STARTUP, MetricType.FRAME_TIMING),
+                requiredMetrics = setOf(MetricType.FRAME_TIMING)
+            ),
+            capabilities = listOf(
+                MetricCapability(MetricType.STARTUP, supported = true, reason = AvailabilityReason.SUPPORTED),
+                MetricCapability(
+                    metric = MetricType.FRAME_TIMING,
+                    supported = false,
+                    reason = AvailabilityReason.RUNTIME_ERROR,
+                    details = "Frame probe threw before measurement."
+                )
+            )
+        )
+
+        assertEquals(listOf(MetricType.STARTUP), result.selectedMetrics)
+        assertFalse(result.requiredMetricsSatisfied)
+        assertFalse(result.canRun)
+    }
+
+    @Test
+    fun `duplicates are collapsed for deterministic reporting`() {
+        val result = BenchmarkMetricSelector.select(
+            request = MetricSelectionRequest(
+                requestedMetrics = listOf(MetricType.STARTUP, MetricType.STARTUP, MetricType.MEMORY)
+            ),
+            capabilities = listOf(
+                MetricCapability(MetricType.STARTUP, supported = true, reason = AvailabilityReason.SUPPORTED),
+                MetricCapability(MetricType.MEMORY, supported = false, reason = AvailabilityReason.HW_UNSUPPORTED)
+            )
+        )
+
+        assertEquals(listOf(MetricType.STARTUP, MetricType.MEMORY), result.requestedMetrics)
+        assertEquals(listOf(MetricType.STARTUP), result.selectedMetrics)
+        assertEquals(listOf(MetricType.MEMORY), result.skippedMetrics.map { it.metric })
+    }
+
+    @Test
+    fun `selection result serializes requested selected and skipped metrics`() {
+        val result = MetricSelectionResult(
+            requestedMetrics = listOf(MetricType.STARTUP, MetricType.NETWORK),
+            selectedMetrics = listOf(MetricType.STARTUP),
+            skippedMetrics = listOf(
+                MetricCapability(
+                    metric = MetricType.NETWORK,
+                    supported = false,
+                    reason = AvailabilityReason.NOT_CONFIGURED,
+                    details = "Network metrics are not part of startup benchmarks."
+                )
+            ),
+            requiredMetricsSatisfied = true
+        )
+
+        val payload = json.encodeToString(result)
+
+        assertTrue(payload.contains("\"requestedMetrics\":[\"startup\",\"network\"]"))
+        assertTrue(payload.contains("\"selectedMetrics\":[\"startup\"]"))
+        assertTrue(payload.contains("\"reason\":\"not_configured\""))
+
+        assertEquals(result, Json.decodeFromString<MetricSelectionResult>(payload))
+    }
+
+    @Test
+    fun `request rejects empty requested metrics`() {
+        assertFailsWith<IllegalArgumentException> {
+            MetricSelectionRequest(requestedMetrics = emptyList())
+        }
+    }
+
+    @Test
+    fun `request rejects required metrics outside requested set`() {
+        assertFailsWith<IllegalArgumentException> {
+            MetricSelectionRequest(
+                requestedMetrics = listOf(MetricType.STARTUP),
+                requiredMetrics = setOf(MetricType.FRAME_TIMING)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds pure benchmark metric-selection models for requested, selected, and skipped metrics.
- Records unsupported/missing capabilities with explicit availability reasons before instrumentation metric objects are built.
- Adds JVM unit tests for supported, unsupported, missing, required, duplicate, and serialized reporting paths.

## Test Plan
- [x] JAVA_HOME=$HOME/.jdks/temurin-17-new bash ./gradlew :shared:testDebugUnitTest --console=plain
- [x] git diff --cached --check