### PR TITLE
test: wire target-specific benchmark class tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,20 +60,22 @@ compose-vs-views/
    ```bash
    # Simple run without specifying a device serial (works when only one device is connected)
    ./gradlew :benchmark:connectedBenchmarkAndroidTest \
+     -PbenchmarkTarget=:app-compose \
      -Pandroid.testInstrumentationRunnerArguments.benchmarkTargetPackage=dev.egarcia.andperf.compose \
      -Pandroid.testInstrumentationRunnerArguments.class=dev.egarcia.andperf.benchmark.ComposeViewBenchmarks#coldStartup_compose \
      --info --stacktrace
    
    # Run the corresponding View cold-start benchmark (explicit serial)
    ./gradlew :benchmark:connectedBenchmarkAndroidTest \
+     -PbenchmarkTarget=:app-view \
      -Pandroid.testInstrumentationRunnerArguments.serial=ABCD12BB3AB \
      -Pandroid.testInstrumentationRunnerArguments.benchmarkTargetPackage=dev.egarcia.andperf.view \
      -Pandroid.testInstrumentationRunnerArguments.class=dev.egarcia.andperf.benchmark.ComposeViewBenchmarks#coldStartup_view \
      --info --stacktrace
 
    # Or run both sequentially in your shell (keeps outputs separate)
-   ./gradlew :benchmark:connectedBenchmarkAndroidTest -Pandroid.testInstrumentationRunnerArguments.benchmarkTargetPackage=dev.egarcia.andperf.compose -Pandroid.testInstrumentationRunnerArguments.class=dev.egarcia.andperf.benchmark.ComposeViewBenchmarks#coldStartup_compose --info --stacktrace && \
-   ./gradlew :benchmark:connectedBenchmarkAndroidTest -Pandroid.testInstrumentationRunnerArguments.benchmarkTargetPackage=dev.egarcia.andperf.view -Pandroid.testInstrumentationRunnerArguments.class=dev.egarcia.andperf.benchmark.ComposeViewBenchmarks#coldStartup_view --info --stacktrace
+   ./gradlew :benchmark:connectedBenchmarkAndroidTest -PbenchmarkTarget=:app-compose -Pandroid.testInstrumentationRunnerArguments.benchmarkTargetPackage=dev.egarcia.andperf.compose -Pandroid.testInstrumentationRunnerArguments.class=dev.egarcia.andperf.benchmark.ComposeViewBenchmarks#coldStartup_compose --info --stacktrace && \
+   ./gradlew :benchmark:connectedBenchmarkAndroidTest -PbenchmarkTarget=:app-view -Pandroid.testInstrumentationRunnerArguments.benchmarkTargetPackage=dev.egarcia.andperf.view -Pandroid.testInstrumentationRunnerArguments.class=dev.egarcia.andperf.benchmark.ComposeViewBenchmarks#coldStartup_view --info --stacktrace
    ```
    
    Note: passing the device serial is optional
@@ -81,9 +83,20 @@ compose-vs-views/
    - It becomes required when multiple devices are attached or when you need deterministic selection (CI).
    - Also note the `--info` and `--stacktrace` flags are optional diagnostic flags (use them for more logging or on failures).
 
-   Note: some projects provide a convenience task (for example `runAllBenchmarks`) — check your `build.gradle.kts` for such wrappers; if present you can run it like:
+   Note: this project also provides convenience tasks for target-specific benchmark runs:
    ```bash
-   ./gradlew runAllBenchmarks --info --stacktrace
+   # Verify task wiring without requiring a device.
+   bash ./gradlew runBenchmarkComposeClass --dry-run
+   bash ./gradlew runBenchmarkViewClass --dry-run
+
+   # Run one default cold-start method against each intended app package.
+   bash ./gradlew runBenchmarkComposeClass --info --stacktrace
+   bash ./gradlew runBenchmarkViewClass --info --stacktrace
+
+   # Override the class/method while preserving the target app/package wiring.
+   bash ./gradlew runBenchmarkViewClass \
+     -PbenchmarkClass=dev.egarcia.andperf.benchmark.ComposeViewBenchmarks#scroll_view \
+     --info --stacktrace
    ```
 
 3. Where to find results and traces

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 // Convenience benchmark tasks (use Exec tasks to avoid deprecated inline `exec {}`)
 val deviceSerial: String? = (project.findProperty("deviceSerial") as? String)
+val benchmarkClassOverride: String? = (project.findProperty("benchmarkClass") as? String)
 
 // Assemble+install for each app as Exec tasks
 tasks.register<Exec>("assembleInstallCompose") {
@@ -47,12 +48,16 @@ fun testClassForTarget(targetProject: String): String = when (targetProject) {
     else -> ""
 }
 
-fun buildBenchmarkCmd(targetProject: String): List<String> {
-    val cmd = mutableListOf("./gradlew", ":benchmark:assembleBenchmark", ":benchmark:connectedBenchmarkAndroidTest", "-PbenchmarkTarget=$targetProject")
+fun buildBenchmarkCmd(targetProject: String, singleClassOnly: Boolean = false): List<String> {
+    val cmd = mutableListOf("bash", "./gradlew", ":benchmark:assembleBenchmark", ":benchmark:connectedBenchmarkAndroidTest", "-PbenchmarkTarget=$targetProject")
     deviceSerial?.let { cmd.add("-Pandroid.testInstrumentationRunnerArguments.serial=$it") }
     // Pass the intended package down to the instrumentation APK so tests can skip non-targets
     cmd.add("-Pandroid.testInstrumentationRunnerArguments.benchmarkTargetPackage=${projectPathToPackage(targetProject)}")
-    val testClass = testClassForTarget(targetProject)
+    val testClass = if (singleClassOnly) {
+        benchmarkClassOverride ?: testClassForTarget(targetProject)
+    } else {
+        benchmarkClassOverride.orEmpty()
+    }
     if (testClass.isNotBlank()) {
         cmd.add("-Pandroid.testInstrumentationRunnerArguments.class=$testClass")
     }
@@ -68,11 +73,27 @@ tasks.register<Exec>("benchmarkComposeRun") {
     }
 }
 
+tasks.register<Exec>("runBenchmarkComposeClass") {
+    group = "benchmark"
+    description = "Run the Compose benchmark class against :app-compose; override with -PbenchmarkClass=<class#method>"
+    doFirst {
+        commandLine(buildBenchmarkCmd(":app-compose", singleClassOnly = true))
+    }
+}
+
 tasks.register<Exec>("benchmarkViewRun") {
     group = "benchmark"
     description = "Run :benchmark:connectedBenchmarkAndroidTest for :app-view"
     doFirst {
         commandLine(buildBenchmarkCmd(":app-view"))
+    }
+}
+
+tasks.register<Exec>("runBenchmarkViewClass") {
+    group = "benchmark"
+    description = "Run the View benchmark class against :app-view; override with -PbenchmarkClass=<class#method>"
+    doFirst {
+        commandLine(buildBenchmarkCmd(":app-view", singleClassOnly = true))
     }
 }
 


### PR DESCRIPTION
## Summary
- Add target-specific `runBenchmarkComposeClass` and `runBenchmarkViewClass` convenience tasks.
- Ensure wrappers invoke Gradle through `bash ./gradlew`, pass `-PbenchmarkTarget` for the selected app, and propagate `benchmarkTargetPackage` plus default/override class filters.
- Update README benchmark examples so manual and wrapper commands configure the intended benchmark target.

## Verification
- `bash ./gradlew runBenchmarkComposeClass --dry-run`
- `bash ./gradlew runBenchmarkViewClass --dry-run`
- `bash ./gradlew :benchmark:assembleBenchmark -PbenchmarkTarget=:app-compose`
- `bash ./gradlew :benchmark:assembleBenchmark -PbenchmarkTarget=:app-view`
- `git diff --check`
- `bash ./gradlew test --console=plain`

## Notes
- Connected single-class benchmark execution was not run in this cron environment because `adb` is not available on PATH and no physical/emulator device could be addressed from the job.
