### PR TITLE
feat: add metric capability reporting

### DIFF
--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -47,6 +47,8 @@ android {
 kotlin { jvmToolchain(17) }
 
 dependencies {
+    implementation(project(":shared"))
+
     // Use explicit coordinates so the test/runtime classpath contains the benchmark and test
     // libraries that the benchmark sources import (MacrobenchmarkRule, AndroidJUnit4, etc.).
     implementation(libs.benchmark.macro)

--- a/benchmark/src/androidTest/java/dev/egarcia/andperf/benchmark/BenchmarkUtils.kt
+++ b/benchmark/src/androidTest/java/dev/egarcia/andperf/benchmark/BenchmarkUtils.kt
@@ -1,0 +1,89 @@
+package dev.egarcia.andperf.benchmark
+
+import android.os.Build
+import android.util.Log
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.MacrobenchmarkRule
+import androidx.benchmark.macro.Metric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import dev.egarcia.andperf.shared.capability.DeviceInfo
+import dev.egarcia.andperf.shared.capability.MetricCapabilityProbe
+import dev.egarcia.andperf.shared.capability.MetricRequirements
+import dev.egarcia.andperf.shared.capability.MetricType
+import dev.egarcia.andperf.shared.capability.ProbeEnvironment
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+private const val TAG = "BenchmarkCapability"
+
+private val capabilityJson = Json {
+    encodeDefaults = true
+    prettyPrint = false
+}
+
+/**
+ * Device/OS snapshot used by capability reports emitted from instrumented benchmark runs.
+ */
+fun currentDeviceInfo(): DeviceInfo = DeviceInfo(
+    manufacturer = Build.MANUFACTURER ?: "unknown",
+    model = Build.MODEL ?: "unknown",
+    device = Build.DEVICE ?: "unknown",
+    sdkInt = Build.VERSION.SDK_INT,
+    abi = Build.SUPPORTED_ABIS.firstOrNull() ?: Build.CPU_ABI ?: "unknown",
+    buildId = Build.ID ?: "unknown",
+    fingerprint = Build.FINGERPRINT ?: "unknown"
+)
+
+/**
+ * Converts requested metric families to concrete Macrobenchmark metrics after emitting a
+ * structured capability report. Unsupported metric families are excluded before measurement.
+ */
+fun sanitizedMetricsForBenchmark(
+    targetPackage: String,
+    requestedMetrics: List<MetricType>,
+    probe: MetricCapabilityProbe = MetricCapabilityProbe(),
+    environment: ProbeEnvironment = ProbeEnvironment(deviceInfo = currentDeviceInfo())
+): List<Metric> {
+    val requirements = requestedMetrics.map { metric ->
+        when (metric) {
+            MetricType.STARTUP -> MetricRequirements.Startup
+            MetricType.FRAME_TIMING -> MetricRequirements.FrameTiming
+            else -> error("No Macrobenchmark metric mapping exists for $metric")
+        }
+    }
+    val report = probe.report(targetPackage, environment, requirements)
+
+    Log.i(TAG, "Metric capability report: ${report.humanReadableSummary()}")
+    Log.i(TAG, "Metric capability JSON: ${capabilityJson.encodeToString(report)}")
+
+    return report.available.map { metric ->
+        when (metric) {
+            MetricType.STARTUP -> StartupTimingMetric()
+            MetricType.FRAME_TIMING -> FrameTimingMetric()
+            else -> error("No Macrobenchmark metric mapping exists for $metric")
+        }
+    }
+}
+
+fun MacrobenchmarkRule.measureStartupWithCapabilityReport(
+    packageName: String,
+    requestedMetrics: List<MetricType>,
+    startupMode: StartupMode = StartupMode.COLD,
+    iterations: Int = 3
+) {
+    val metrics = sanitizedMetricsForBenchmark(
+        targetPackage = packageName,
+        requestedMetrics = requestedMetrics
+    )
+
+    check(metrics.isNotEmpty()) { "No supported benchmark metrics remain for $packageName" }
+
+    measureRepeated(
+        packageName = packageName,
+        metrics = metrics,
+        iterations = iterations,
+        startupMode = startupMode,
+        measureBlock = { startActivityAndWait() }
+    )
+}

--- a/benchmark/src/androidTest/java/dev/egarcia/andperf/benchmark/ComposeViewBenchmarks.kt
+++ b/benchmark/src/androidTest/java/dev/egarcia/andperf/benchmark/ComposeViewBenchmarks.kt
@@ -1,11 +1,9 @@
 package dev.egarcia.andperf.benchmark
 
-import androidx.benchmark.macro.FrameTimingMetric
 import androidx.benchmark.macro.MacrobenchmarkRule
-import androidx.benchmark.macro.StartupMode
-import androidx.benchmark.macro.StartupTimingMetric
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import dev.egarcia.andperf.shared.capability.MetricType
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
@@ -38,12 +36,9 @@ class ComposeViewBenchmarks {
         Assume.assumeTrue("Skipping test because target package $pkg is not installed", isPackageInstalled(pkg))
 
         try {
-            rule.measureRepeated(
+            rule.measureStartupWithCapabilityReport(
                 packageName = pkg,
-                metrics = listOf(StartupTimingMetric(), FrameTimingMetric()),
-                iterations = 3,
-                startupMode = StartupMode.COLD,
-                measureBlock = { startActivityAndWait() }
+                requestedMetrics = listOf(MetricType.STARTUP, MetricType.FRAME_TIMING)
             )
         } catch (t: Throwable) {
             // Some devices/targets may not produce frame timing results or other metric errors may occur.
@@ -62,12 +57,9 @@ class ComposeViewBenchmarks {
         Assume.assumeTrue("Skipping test because target package $pkg is not installed", isPackageInstalled(pkg))
 
         try {
-            rule.measureRepeated(
+            rule.measureStartupWithCapabilityReport(
                 packageName = pkg,
-                metrics = listOf(StartupTimingMetric()), // FrameTimingMetric removed for view target to avoid empty results
-                iterations = 3,
-                startupMode = StartupMode.COLD,
-                measureBlock = { startActivityAndWait() }
+                requestedMetrics = listOf(MetricType.STARTUP, MetricType.FRAME_TIMING)
             )
         } catch (t: Throwable) {
             // Some devices/targets may not produce frame timing results or other metric errors may occur.

--- a/shared/src/main/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModels.kt
+++ b/shared/src/main/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModels.kt
@@ -95,3 +95,127 @@ data class DeviceInfo(
     val buildId: String,
     val fingerprint: String
 )
+
+/**
+ * Minimal environment supplied to metric probes. Keeping this separate from Android framework
+ * classes lets unit tests exercise classification without a device.
+ */
+data class ProbeEnvironment(
+    val deviceInfo: DeviceInfo,
+    val hasHardwareCounters: Boolean = true,
+    val hasShellMetricPermissions: Boolean = true
+)
+
+/**
+ * Declarative requirement for a metric family requested by a benchmark.
+ */
+data class MetricRequirement(
+    val metric: MetricType,
+    val minSdk: Int,
+    val requiresHardwareCounters: Boolean = false,
+    val requiresShellMetricPermissions: Boolean = false
+)
+
+/**
+ * Serializable metadata emitted for each benchmark run before unsupported metrics are removed.
+ */
+@Serializable
+data class MetricCapabilityReport(
+    val targetPackage: String,
+    val device: DeviceInfo,
+    val requested: List<MetricType>,
+    val capabilities: List<MetricCapability>
+) {
+    val available: List<MetricType>
+        get() = capabilities.filter { it.supported }.map { it.metric }
+
+    val skipped: List<MetricCapability>
+        get() = capabilities.filterNot { it.supported }
+
+    fun humanReadableSummary(): String {
+        val skippedSummary = skipped.joinToString(separator = "; ") { capability ->
+            "${capability.metric}: ${capability.reason} (${capability.message})"
+        }.ifBlank { "none" }
+
+        return "target=$targetPackage, sdk=${device.sdkInt}, requested=$requested, " +
+            "available=$available, skipped=$skippedSummary"
+    }
+}
+
+/**
+ * Builds a metric capability report from declarative requirements and optional device probes.
+ */
+class MetricCapabilityProbe(
+    private val probeOverrides: Map<MetricType, (ProbeEnvironment) -> MetricCapability?> = emptyMap()
+) {
+    fun report(
+        targetPackage: String,
+        environment: ProbeEnvironment,
+        requirements: List<MetricRequirement>
+    ): MetricCapabilityReport {
+        val capabilities = requirements.map { requirement -> classify(environment, requirement) }
+
+        return MetricCapabilityReport(
+            targetPackage = targetPackage,
+            device = environment.deviceInfo,
+            requested = requirements.map { it.metric },
+            capabilities = capabilities
+        )
+    }
+
+    private fun classify(
+        environment: ProbeEnvironment,
+        requirement: MetricRequirement
+    ): MetricCapability {
+        val override = probeOverrides[requirement.metric]
+        if (override != null) {
+            return try {
+                override(environment) ?: defaultClassify(environment, requirement)
+            } catch (t: Throwable) {
+                MetricCapability(
+                    metric = requirement.metric,
+                    supported = false,
+                    reason = AvailabilityReason.RUNTIME_ERROR,
+                    details = t.message ?: "Probe threw ${t::class.simpleName}."
+                )
+            }
+        }
+
+        return defaultClassify(environment, requirement)
+    }
+
+    private fun defaultClassify(
+        environment: ProbeEnvironment,
+        requirement: MetricRequirement
+    ): MetricCapability = when {
+        environment.deviceInfo.sdkInt < requirement.minSdk -> MetricCapability(
+            metric = requirement.metric,
+            supported = false,
+            reason = AvailabilityReason.OS_TOO_OLD,
+            details = "Requires API ${requirement.minSdk}+; device is API ${environment.deviceInfo.sdkInt}."
+        )
+
+        requirement.requiresHardwareCounters && !environment.hasHardwareCounters -> MetricCapability(
+            metric = requirement.metric,
+            supported = false,
+            reason = AvailabilityReason.HW_UNSUPPORTED
+        )
+
+        requirement.requiresShellMetricPermissions && !environment.hasShellMetricPermissions -> MetricCapability(
+            metric = requirement.metric,
+            supported = false,
+            reason = AvailabilityReason.PERMISSION_DENIED
+        )
+
+        else -> MetricCapability(
+            metric = requirement.metric,
+            supported = true,
+            reason = AvailabilityReason.SUPPORTED
+        )
+    }
+}
+
+object MetricRequirements {
+    val Startup = MetricRequirement(metric = MetricType.STARTUP, minSdk = 23)
+    val FrameTiming = MetricRequirement(metric = MetricType.FRAME_TIMING, minSdk = 23)
+}

--- a/shared/src/test/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModelsTest.kt
+++ b/shared/src/test/java/dev/egarcia/andperf/shared/capability/MetricCapabilityModelsTest.kt
@@ -13,6 +13,16 @@ class MetricCapabilityModelsTest {
         prettyPrint = false
     }
 
+    private val device = DeviceInfo(
+        manufacturer = "Google",
+        model = "Pixel 8",
+        device = "shiba",
+        sdkInt = 34,
+        abi = "arm64-v8a",
+        buildId = "AP4A.250105.001",
+        fingerprint = "google/shiba/shiba:14/AP4A.250105.001/123:user/release-keys"
+    )
+
     @Test
     fun `resolveMessage prefers explicit details`() {
         val capability = MetricCapability(
@@ -84,18 +94,99 @@ class MetricCapabilityModelsTest {
 
     @Test
     fun `device info round trip retains identity`() {
-        val info = DeviceInfo(
-            manufacturer = "Google",
-            model = "Pixel 8",
-            device = "shiba",
-            sdkInt = 34,
-            abi = "arm64-v8a",
-            buildId = "AP4A.250105.001",
-            fingerprint = "google/shiba/shiba:14/AP4A.250105.001/123:user/release-keys"
+        val payload = json.encodeToString(device)
+        val decoded = Json.decodeFromString<DeviceInfo>(payload)
+        assertEquals(device, decoded)
+    }
+
+    @Test
+    fun `probe classifies supported metrics`() {
+        val report = MetricCapabilityProbe().report(
+            targetPackage = "dev.egarcia.andperf.compose",
+            environment = ProbeEnvironment(deviceInfo = device),
+            requirements = listOf(MetricRequirements.Startup, MetricRequirements.FrameTiming)
         )
 
-        val payload = json.encodeToString(info)
-        val decoded = Json.decodeFromString<DeviceInfo>(payload)
-        assertEquals(info, decoded)
+        assertEquals(listOf(MetricType.STARTUP, MetricType.FRAME_TIMING), report.requested)
+        assertEquals(listOf(MetricType.STARTUP, MetricType.FRAME_TIMING), report.available)
+        assertTrue(report.skipped.isEmpty())
+        assertTrue(report.humanReadableSummary().contains("skipped=none"))
+    }
+
+    @Test
+    fun `probe classifies unsupported metrics when sdk is too old`() {
+        val oldDevice = device.copy(sdkInt = 22)
+        val report = MetricCapabilityProbe().report(
+            targetPackage = "dev.egarcia.andperf.view",
+            environment = ProbeEnvironment(deviceInfo = oldDevice),
+            requirements = listOf(MetricRequirements.Startup, MetricRequirements.FrameTiming)
+        )
+
+        assertTrue(report.available.isEmpty())
+        assertEquals(listOf(MetricType.STARTUP, MetricType.FRAME_TIMING), report.skipped.map { it.metric })
+        assertEquals(AvailabilityReason.OS_TOO_OLD, report.skipped.first().reason)
+        assertTrue(report.skipped.first().message.contains("Requires API 23+"))
+    }
+
+    @Test
+    fun `probe preserves explicit unsupported probe result`() {
+        val probe = MetricCapabilityProbe(
+            probeOverrides = mapOf(
+                MetricType.FRAME_TIMING to {
+                    MetricCapability(
+                        metric = MetricType.FRAME_TIMING,
+                        supported = false,
+                        reason = AvailabilityReason.NO_DATA_COLLECTED,
+                        details = "Dry-run probe produced no frame samples."
+                    )
+                }
+            )
+        )
+
+        val report = probe.report(
+            targetPackage = "dev.egarcia.andperf.view",
+            environment = ProbeEnvironment(deviceInfo = device),
+            requirements = listOf(MetricRequirements.Startup, MetricRequirements.FrameTiming)
+        )
+
+        assertEquals(listOf(MetricType.STARTUP), report.available)
+        assertEquals(MetricType.FRAME_TIMING, report.skipped.single().metric)
+        assertEquals(AvailabilityReason.NO_DATA_COLLECTED, report.skipped.single().reason)
+    }
+
+    @Test
+    fun `probe converts runtime errors to skipped capabilities`() {
+        val probe = MetricCapabilityProbe(
+            probeOverrides = mapOf(
+                MetricType.FRAME_TIMING to { throw IllegalStateException("probe failed") }
+            )
+        )
+
+        val report = probe.report(
+            targetPackage = "dev.egarcia.andperf.view",
+            environment = ProbeEnvironment(deviceInfo = device),
+            requirements = listOf(MetricRequirements.FrameTiming)
+        )
+
+        assertTrue(report.available.isEmpty())
+        assertEquals(AvailabilityReason.RUNTIME_ERROR, report.skipped.single().reason)
+        assertEquals("probe failed", report.skipped.single().message)
+    }
+
+    @Test
+    fun `capability report serializes requested and skipped metadata`() {
+        val report = MetricCapabilityProbe().report(
+            targetPackage = "dev.egarcia.andperf.compose",
+            environment = ProbeEnvironment(deviceInfo = device.copy(sdkInt = 22)),
+            requirements = listOf(MetricRequirements.Startup)
+        )
+
+        val payload = json.encodeToString(report)
+        assertTrue(payload.contains("\"targetPackage\":\"dev.egarcia.andperf.compose\""))
+        assertTrue(payload.contains("\"requested\":[\"startup\"]"))
+        assertTrue(payload.contains("\"reason\":\"os_too_old\""))
+
+        val decoded = Json.decodeFromString<MetricCapabilityReport>(payload)
+        assertEquals(report, decoded)
     }
 }


### PR DESCRIPTION
## Summary
- Adds a shared metric capability probe/config model that records requested, available, and skipped metric families with explicit `AvailabilityReason` metadata.
- Adds benchmark-side capability reporting that logs human-readable and JSON metadata before converting supported metric families to Macrobenchmark metrics.
- Refactors Compose and View benchmark runs to request comparable startup + frame-timing metric families through the new capability-reporting helper.
- Expands unit tests for supported, unsupported, explicit-probe-skip, runtime-error, and JSON reporting cases.

## Test Plan
- [x] `ANDROID_HOME=/home/egarcia/Android/Sdk bash ./gradlew :shared:testDebugUnitTest --console=plain`
- [x] `ANDROID_HOME=/home/egarcia/Android/Sdk bash ./gradlew :benchmark:assembleBenchmark -PbenchmarkTarget=:app-compose --console=plain`
- [x] `ANDROID_HOME=/home/egarcia/Android/Sdk bash ./gradlew :benchmark:assembleBenchmark -PbenchmarkTarget=:app-view --console=plain`
- [x] `ANDROID_HOME=/home/egarcia/Android/Sdk bash ./gradlew test --console=plain`

Connected benchmark execution was not run in this cron environment because no physical/emulator device was available.